### PR TITLE
Update kustomizaion manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ defaultBackend:
 
 ## Getting started - Kustomize
 
-Kustomize manifest are provided with both ingress controller and default backend deployment
+Kustomize manifest are provided with both ingress controller and default backend deployment.
 
 ```bash
-kubectl apply -f k8s/
+kubectl apply -k k8s/
+Or
+kustomize build k8s | kubectl apply -f -
 ```
 
 ## Credits

--- a/k8s/backend/deployment.yaml
+++ b/k8s/backend/deployment.yaml
@@ -10,6 +10,9 @@ spec:
         - name: ingress-nginx-default-backend
           image: ghcr.io/181192/custom-error-pages
           imagePullPolicy: IfNotPresent
+          env: 
+            - name: ERROR_FILES_PATH
+              value: ./themes/knockout
           securityContext:
             runAsUser: 65534
           ports:

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -21,6 +21,7 @@ spec:
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/$(NGINX_CONFIGMAP_NAME)
+            - --default-backend-service=$(POD_NAMESPACE)/ingress-nginx-default-backend
             - --publish-service=$(POD_NAMESPACE)/$(SERVICE_NAME)
             - --election-id=ingress-controller-leader
             - --ingress-class=nginx

--- a/k8s/base/ingress-class.yaml
+++ b/k8s/base/ingress-class.yaml
@@ -1,6 +1,0 @@
-apiVersion: networking.k8s.io/v1
-kind: IngressClass
-metadata:
-  name: nginx
-spec:
-  controller: k8s.io/ingress-nginx

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
   - cluster-role-binding.yaml
   - cluster-role.yaml
   - deployment.yaml
-  - ingress-class.yaml
   - role-binding.yaml
   - role.yaml
   - service.yaml
@@ -46,5 +45,6 @@ configMapGenerator:
       - proxy-read-timeout="600"
       - proxy-send-timeout="600"
       - server-name-hash-bucket-size="256"
+      - custom-http-errors="404,500,501,502,503"
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
This PR updates kustomization manifests by setting default backend for ingress so that everything ready when deploying with kustomize.

Fix: https://github.com/181192/custom-error-pages/issues/5
Thanks